### PR TITLE
disable logging on all other events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 var SeedReporter = function(baseReporterDecorator) {
   baseReporterDecorator(this);
 
+  var noop = function() {};
+
+  this.onBrowserError = noop;
+  this.onBrowserLog = noop;
+  this.onSpecComplete = noop;
+  this.onRunComplete = noop;
+
   this.onBrowserComplete = function(_browser, result) {
     if (result.order && result.order.random && result.order.seed) {
       this.write(`Jasmine Seed: Randomized with seed ${result.order.seed}. Set config option 'karma.client.jasmine.random' to re-run with same order.\n`);


### PR DESCRIPTION
First off, thanks for publishing this reporter!

In my case, I'm also using the [spec reporter](https://github.com/mlex/karma-spec-reporter#readme) and after adding the seed reporter, I noticed logs were getting emitted twice. Turns out the `baseReporterDecorator` also adds some default logging for various events (onBrowserError, onBrowserLog, etc). Since the purpose of this reporter is to only report jasmine's seed, I overrode the other event handlers to do nothing.